### PR TITLE
Feature: 포켓몬 디테일 페이지 구현

### DIFF
--- a/src/components/Dashboard.jsx
+++ b/src/components/Dashboard.jsx
@@ -1,6 +1,31 @@
 import pokeballImage from "../assets/pokeball.png";
 import { PokemonCard } from "./PokemonCard";
 
+const MAX_POKEMON_NUM = 6;
+
+const dashboardStyle = {
+  display: "flex",
+  flexDirection: "column",
+  alignItems: "center",
+  justifyContent: "center",
+};
+
+const boxesStyle = {
+  display: "flex",
+};
+
+const boxStyle = {
+  width: "100px",
+  height: "100px",
+  border: "1px solid black",
+};
+
+const imageStyle = {
+  width: "100%",
+  height: "100%",
+  objectFit: "cover",
+};
+
 /**
  * * 사용자가 선택한 포켓몬을 표시하는 컴포넌트
  * @param {array} myPokemons - 사용자가 선택한 포켓몬 객체 리스트 [
@@ -9,30 +34,7 @@ import { PokemonCard } from "./PokemonCard";
  * @param {Function} removePokemon - 포켓몬 삭제 핸들러 함수 (id) => void
  */
 export const Dashboard = ({ myPokemons, removePokemon }) => {
-  const dashboardStyle = {
-    display: "flex",
-    flexDirection: "column",
-    alignItems: "center",
-    justifyContent: "center",
-  };
-
-  const boxesStyle = {
-    display: "flex",
-  };
-
-  const boxStyle = {
-    width: "100px",
-    height: "100px",
-    border: "1px solid black",
-  };
-
-  const imageStyle = {
-    width: "100%",
-    height: "100%",
-    objectFit: "cover",
-  };
-
-  const MAX_POKEMON_NUM = 6;
+  const availableCount = MAX_POKEMON_NUM - myPokemons.length;
 
   return (
     <div style={dashboardStyle}>
@@ -44,18 +46,16 @@ export const Dashboard = ({ myPokemons, removePokemon }) => {
             key={myPokemon.id}
             data={myPokemon}
             buttonType="삭제"
-            addPokemon={() => removePokemon(myPokemon.id)}
+            onClick={removePokemon}
           />
         ))}
 
         {/* 남은 공간은 포켓볼 그리기*/}
-        {Array.from({ length: MAX_POKEMON_NUM - myPokemons.length }).map(
-          (_, index) => (
-            <div style={boxStyle} key={index}>
-              <img style={imageStyle} src={pokeballImage} alt="포켓볼" />
-            </div>
-          )
-        )}
+        {Array.from({ length: availableCount }).map((_, index) => (
+          <div style={boxStyle} key={index}>
+            <img style={imageStyle} src={pokeballImage} alt="포켓볼" />
+          </div>
+        ))}
       </div>
     </div>
   );

--- a/src/components/PokemonCard.jsx
+++ b/src/components/PokemonCard.jsx
@@ -1,27 +1,43 @@
+import { useNavigate } from "react-router-dom";
+
+const cardStyle = {
+  height: "300px",
+  border: "1px solid black",
+  display: "flex",
+  flexDirection: "column",
+  alignItems: "center",
+  justifyContent: "center",
+};
+
 /**
  * * 포켓몬 카드 하나를 나타내는 컴포넌트
  * @param {Object} data - 포켓몬 정보 {img_url, korean_name, types, id, description}
  * @param {string} buttonType - 버튼 타입 ("추가" 또는 "삭제")
- * @param {Function} addPokemon - 포켓몬 추가 핸들러 함수 (id) => void
+ * @param {Function} onClick - 포켓몬 추가 및 삭제 핸들러 함수
+ *    - 포켓몬 추가: ({{img_url, korean_name, types, id, description}}) => void
+ *    - 포켓몬 삭제: (id) => void
  */
-export const PokemonCard = ({ data, buttonType, addPokemon }) => {
+export const PokemonCard = ({ data, buttonType, onClick }) => {
   const { img_url, korean_name, id } = data;
+  const navigate = useNavigate();
 
-  const cardStyle = {
-    height: "300px",
-    border: "1px solid black",
-    display: "flex",
-    flexDirection: "column",
-    alignItems: "center",
-    justifyContent: "center",
+  // * 카드 상세 페이지 이동 핸들러
+  const goToDetail = (id) => {
+    navigate(`/detail?id=${id}`);
+  };
+
+  // * 카드와 버튼 클릭 이벤트 버블링 방지용 함수
+  const buttonClick = (e) => {
+    e.stopPropagation();
+    onClick(buttonType === "추가" ? data : id);
   };
 
   return (
-    <div style={cardStyle}>
+    <div onClick={() => goToDetail(id)} style={cardStyle}>
       <img src={img_url} />
       <div>{korean_name}</div>
       <div>No. {id}</div>
-      <button onClick={() => addPokemon(data)}>{buttonType}</button>
+      <button onClick={(e) => buttonClick(e)}>{buttonType}</button>
     </div>
   );
 };

--- a/src/components/PokemonDetail.jsx
+++ b/src/components/PokemonDetail.jsx
@@ -1,0 +1,16 @@
+/**
+ * * 포켓몬의 디테일 정보를 표시하는 컴포넌트
+ * @param pokemon - 포켓몬 정보 {img_url, korean_name, types, id, description}
+ */
+export const PokemonDetail = ({ pokemon }) => {
+  const { img_url, korean_name, types, description } = pokemon;
+
+  return (
+    <div>
+      <img src={img_url} />
+      <div>{korean_name}</div>
+      <div>타입: {types} </div>
+      <div>{description}</div>
+    </div>
+  );
+};

--- a/src/components/PokemonList.jsx
+++ b/src/components/PokemonList.jsx
@@ -1,18 +1,18 @@
 import { PokemonCard } from "./PokemonCard";
 import { MOCK_DATA } from "../data/mockData";
 
+const listStyle = {
+  display: "grid",
+  gridTemplateColumns: "repeat(auto-fit, minmax(150px, 1fr))",
+  alignItems: "center",
+  justifyContent: "center",
+};
+
 /**
  * * 포켓몬 전체 리스트를 카드로 보여주는 컴포넌트
  * @param {Function} addPokemon - 포켓몬 추가 핸들러 함수 (id) => void
  */
 export const PokemonList = ({ addPokemon }) => {
-  const listStyle = {
-    display: "grid",
-    gridTemplateColumns: "repeat(auto-fit, minmax(150px, 1fr))",
-    alignItems: "center",
-    justifyContent: "center",
-  };
-
   return (
     <div style={listStyle}>
       {MOCK_DATA.map((pokemon) => (
@@ -20,7 +20,7 @@ export const PokemonList = ({ addPokemon }) => {
           key={pokemon.id}
           data={pokemon}
           buttonType="추가"
-          addPokemon={addPokemon}
+          onClick={addPokemon}
         />
       ))}
     </div>

--- a/src/pages/Detail.jsx
+++ b/src/pages/Detail.jsx
@@ -1,0 +1,30 @@
+import { useNavigate, useSearchParams } from "react-router-dom";
+import { MOCK_DATA } from "../data/mockData";
+import { PokemonDetail } from "../components/PokemonDetail";
+
+/**
+ * * 포켓몬의 상세 정보를 보여주는 페이지
+ */
+export const Detail = () => {
+  const [searchParams] = useSearchParams();
+  const navigate = useNavigate();
+  const pokemonId = searchParams.get("id");
+  const pokemon = searchPokemon(pokemonId);
+
+  // * id를 통해 해당 포켓몬 데이터를 반환하는 함수
+  const searchPokemon = (id) => {
+    return MOCK_DATA.find((pokemon) => pokemon.id === Number(id));
+  };
+
+  // * 뒤로가기 함수
+  const goToBack = () => {
+    navigate(-1);
+  };
+
+  return (
+    <div>
+      <PokemonDetail pokemon={pokemon} />
+      <button onClick={goToBack}>뒤로 가기</button>
+    </div>
+  );
+};

--- a/src/pages/Dex.jsx
+++ b/src/pages/Dex.jsx
@@ -2,17 +2,21 @@ import { useState } from "react";
 import { Dashboard } from "../components/Dashboard";
 import { PokemonList } from "../components/PokemonList";
 
+const dexStyle = {
+  display: "flex",
+  flexDirection: "column",
+};
+
 /**
  * * 포켓몬 도감 페이지
  */
 export const Dex = () => {
-  const dexStyle = {
-    display: "flex",
-    flexDirection: "column",
-  };
-
   const [myPokemons, setMyPokemons] = useState([]);
 
+  /**
+   * * 포켓몬 추가 이벤트 핸들러
+   * 이미 6개가 선택되었거나 중복 선택을 하는 경우 alert
+   */
   const addPokemon = (newPokemon) => {
     if (myPokemons.length >= 6) {
       alert("더 이상 선택할 수 없습니다.");
@@ -25,11 +29,11 @@ export const Dex = () => {
     setMyPokemons([...myPokemons, newPokemon]);
   };
 
+  // * 포켓몬 삭제 이벤트 핸들러
   const removePokemon = (id) => {
     setMyPokemons((pokemons) =>
       pokemons.filter((pokemon) => pokemon.id !== id)
     );
-    console.log(myPokemons);
   };
 
   return (

--- a/src/shared/Router.jsx
+++ b/src/shared/Router.jsx
@@ -1,13 +1,15 @@
 import { BrowserRouter, Route, Routes } from "react-router-dom";
 import { Home } from "../pages/Home";
 import { Dex } from "../pages/Dex";
+import { Detail } from "../pages/Detail";
 
 export const Router = () => {
   return (
     <BrowserRouter>
       <Routes>
         <Route path="/" element={<Home />} />
-        <Route path="dex" element={<Dex />} />
+        <Route path="/dex" element={<Dex />} />
+        <Route path="/detail" element={<Detail />} />
       </Routes>
     </BrowserRouter>
   );


### PR DESCRIPTION
## 관련 이슈
- close #10 

## 작업 내용
- 디테일 페이지 및 디테일 컴포넌트 생성
- 포켓몬 카드 클릭 시 쿼리 스트링을 통한 페이지 이동
- id로부터 포켓몬 데이터 검색
- 뒤로가기 버튼 구현
- style과 상수를 컴포넌트 외부로 분리

## 스크린샷
<img width="327" alt="image" src="https://github.com/user-attachments/assets/1549db23-5153-43d2-b4d6-24af147752e4" />
