### PR TITLE
Feature: 디테일 페이지에 '추가' 버튼 구현

### DIFF
--- a/src/components/PokemonCard.jsx
+++ b/src/components/PokemonCard.jsx
@@ -70,10 +70,14 @@ export const PokemonCard = ({ data, buttonType, onClick }) => {
     onClick();
   };
 
-  // TODO - 포켓몬 id 값을 3자리로 바꾸기
+  // * 포켓몬 id 값을 3자리로 바꾸는 함수
+  const formatNumber = (number) => {
+    return String(number).padStart(3, "0");
+  };
+
   return (
     <StyledPokemonCard onClick={() => goDetail(id)}>
-      <StyledNumber>No. {id}</StyledNumber>
+      <StyledNumber>No. {formatNumber(id)}</StyledNumber>
       <StyledTitle>{korean_name}</StyledTitle>
       <img src={img_url} />
       <AddButton onClick={(e) => buttonClick(e)}>{buttonType}</AddButton>

--- a/src/components/PokemonDetail.jsx
+++ b/src/components/PokemonDetail.jsx
@@ -4,6 +4,10 @@ import { StyledBox } from "../styles/components/Box";
 import { TitleWithButton } from "../styles/components/Title";
 import { colors } from "../styles/colors";
 import { BiSolidRightArrow } from "react-icons/bi";
+import { StyledButton } from "../styles/components/Button";
+import { useSelector } from "react-redux";
+import { useDispatch } from "react-redux";
+import { addPokemon, removePokemon } from "../redux/slices/pokemonSlice";
 
 const StyledDetail = styled(StyledBox)`
   width: 80%;
@@ -78,13 +82,39 @@ const PokemonType = styled(Types)`
   flex-grow: 1;
 `;
 
+const DetailButtons = styled.div`
+  width: 100%;
+  display: flex;
+  padding: 5px;
+  box-sizing: border-box;
+`;
+
+const DetailButton = styled(StyledButton)`
+  padding: 5px 20px 5px 20px;
+`;
+
 /**
  * * 포켓몬의 디테일 정보를 표시하는 컴포넌트
  * @param {Object} pokemon - 포켓몬 정보 {img_url, korean_name, types, id, description}
  * TODO - 스타일 리팩토링하기
  */
 export const PokemonDetail = ({ pokemon }) => {
-  const { img_url, korean_name, types, description } = pokemon;
+  const { img_url, korean_name, types, id, description } = pokemon;
+  const myPokemons = useSelector((state) => state.pokemonReducer.pokemons);
+  const dispatch = useDispatch();
+
+  const isMypokemon = myPokemons.some((pokemon) => pokemon.id === id);
+
+  // * 포켓몬 소유 여부에 따라 다른 액션을 전달하는 핸들러 함수
+  const detailButtonOnClick = () => {
+    if (isMypokemon) {
+      dispatch(removePokemon(id));
+      alert("삭제되었습니다.");
+    } else {
+      dispatch(addPokemon(pokemon));
+      alert("추가되었습니다.");
+    }
+  };
 
   return (
     <StyledDetail>
@@ -103,6 +133,11 @@ export const PokemonDetail = ({ pokemon }) => {
           <TriangleIcon /> {description}
         </PokemonDesc>
       </PokemonImageBox>
+      <DetailButtons>
+        <DetailButton onClick={detailButtonOnClick}>
+          {isMypokemon ? "삭제" : "추가"}
+        </DetailButton>
+      </DetailButtons>
     </StyledDetail>
   );
 };

--- a/src/styles/components/Button.jsx
+++ b/src/styles/components/Button.jsx
@@ -1,0 +1,24 @@
+import styled from "styled-components";
+import { colors } from "../colors";
+
+export const StyledButton = styled.button`
+  background-color: ${colors.gray.medium};
+  display: flex;
+  align-items: center;
+
+  font-family: "DungGeunMo", sans-serif;
+  border-top: 2px solid ${colors.gray.light};
+  border-left: 2px solid ${colors.gray.light};
+  border-bottom: 2px solid ${colors.gray.dark};
+  border-right: 2px solid ${colors.gray.dark};
+  margin-left: auto;
+  color: black;
+
+  &:active {
+    filter: brightness(0.9);
+    border-top: 2px solid ${colors.gray.dark};
+    border-left: 2px solid ${colors.gray.dark};
+    border-bottom: 2px solid ${colors.gray.light};
+    border-right: 2px solid ${colors.gray.light};
+  }
+`;

--- a/src/styles/components/Title.jsx
+++ b/src/styles/components/Title.jsx
@@ -1,6 +1,7 @@
 import styled from "styled-components";
 import { colors } from "../colors";
 import { useNavigation } from "../../hooks/useNavigation";
+import { StyledButton } from "./Button";
 
 // * Box의 타이틀을 정의하는 스타일 컴포넌트
 export const StyledTitle = styled.div`
@@ -15,30 +16,10 @@ export const StyledTitle = styled.div`
 `;
 
 // * 버튼이 있는 타이틀 스타일 컴포넌트
-const CloseButton = styled.button`
-  background-color: ${colors.gray.medium};
+const CloseButton = styled(StyledButton)`
   height: 100%;
   aspect-ratio: 10/9;
   padding: 4px;
-
-  display: flex;
-  align-items: center;
-
-  font-family: "DungGeunMo", sans-serif;
-  border-top: 2px solid ${colors.gray.light};
-  border-left: 2px solid ${colors.gray.light};
-  border-bottom: 2px solid ${colors.gray.dark};
-  border-right: 2px solid ${colors.gray.dark};
-  margin-left: auto;
-  color: black;
-
-  &:active {
-    filter: brightness(0.95);
-    border-top: 2px solid ${colors.gray.dark};
-    border-left: 2px solid ${colors.gray.dark};
-    border-bottom: 2px solid ${colors.gray.light};
-    border-right: 2px solid ${colors.gray.light};
-  }
 `;
 
 /**


### PR DESCRIPTION
## 관련 이슈
- #21 

## 작업 내용
- 추가 버튼의 스타일을 분리
- 타이틀의 닫기 버튼 스타일을 분리한 컴포넌트로 재사용
- 포켓몬 소유 여부에 따른 액션 전달 핸들러 함수 추가
- 포켓몬 id 값을 3자리로 변경하는 함수 추가